### PR TITLE
feat: [GTM-947]: add group events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/telemetry",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "An analytics wrapper for front end Harness applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 
 import Track from './types/Track'
 import Page from './types/Page'
+import Group from './types/Group'
 
 import initializeAnalytics from './analytics'
 
@@ -101,6 +102,14 @@ export default class Telemetry {
       const augmentedProperties = this.augmentProperties(properties)
 
       this.analytics.page(category, name, augmentedProperties, {}, {})
+    }
+  }
+
+  group(groupProperties: Group): void {
+    if (this.checkInitialized()) {
+      const { groupId, properties = {} } = groupProperties
+      const augmentedProperties = this.augmentProperties(properties)
+      this.analytics.group(groupId, augmentedProperties, {}, {})
     }
   }
 }

--- a/src/types/Group.ts
+++ b/src/types/Group.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+export default interface Group {
+  groupId: string
+  properties?: Record<string, string>
+}


### PR DESCRIPTION
this is to add group event so that FE can send group events that amplitude can filter based off account like BE is doing today: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/ajs-classic/#group