### PR TITLE
feat: [GTM-1078]: delete url from identity and group events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/telemetry",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "An analytics wrapper for front end Harness applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness/telemetry",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "An analytics wrapper for front end Harness applications",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ export default class Telemetry {
     if (this.checkInitialized()) {
       const { userId, properties = {}, options, callback } = identity
       const augmentedProperties = this.augmentProperties(properties)
+      delete augmentedProperties.url
       this.analytics.identify(userId, augmentedProperties, options, callback)
     }
   }
@@ -112,6 +113,7 @@ export default class Telemetry {
     if (this.checkInitialized()) {
       const { groupId, properties = {}, options, callback } = groupProperties
       const augmentedProperties = this.augmentProperties(properties)
+      delete augmentedProperties.url
       this.analytics.group(groupId, augmentedProperties, options, callback)
     }
   }


### PR DESCRIPTION
delete url from identity and group events

the published version is `1.0.41`, hence increase the version to `1.0.42`